### PR TITLE
Delete buf2secret

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,21 +1,21 @@
 {
-  "name" : "Terminal::Readsecret",
-  "source-url" : "git://github.com/titsuki/p6-Terminal-Readsecret.git",
-  "perl" : "6.c",
-  "resources" : [
-    "libraries/readsecret"
+  "authors" : [
+    "titsuki"
   ],
   "build-depends" : [
     "LibraryMake"
   ],
+  "depends" : [ ],
+  "description" : "A perl6 binding of readsecret ( https://github.com/dmeranda/readsecret ) for reading secrets or passwords from a command line secretly (not being displayed)",
+  "name" : "Terminal::Readsecret",
+  "perl" : "6.c",
   "provides" : {
     "Terminal::Readsecret" : "lib/Terminal/Readsecret.pm6"
   },
-  "depends" : [ ],
-  "description" : "A perl6 binding of readsecret ( https://github.com/dmeranda/readsecret ) for reading secrets or passwords from a command line secretly (not being displayed)",
+  "resources" : [
+    "libraries/readsecret"
+  ],
+  "source-url" : "git://github.com/titsuki/p6-Terminal-Readsecret.git",
   "test-depends" : [ ],
-  "version" : "*",
-  "authors" : [
-    "titsuki"
-  ]
+  "version" : "*"
 }

--- a/example/getpass.p6
+++ b/example/getpass.p6
@@ -1,6 +1,6 @@
 use v6;
 use lib $*PROGRAM.dirname ~ '/../lib';
-use Term::Readsecret;
+use Terminal::Readsecret;
 
 my $password = getsecret("password:" );
 say "your password is: " ~ $password;

--- a/example/timeout_getpass.p6
+++ b/example/timeout_getpass.p6
@@ -1,6 +1,6 @@
 use v6;
 use lib $*PROGRAM.dirname ~ '/../lib';
-use Term::Readsecret;
+use Terminal::Readsecret;
 
 my timespec $timeout .= new(tv_sec => 5, tv_nsec => 0);
 my $password = getsecret("password:", $timeout);


### PR DESCRIPTION
buf2secret is deleted, because `Int.new($buf[$i]).chr;` is not a good way considering multi-byte charset.