### PR TITLE
Made Timespec class instead of timespec class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ EXAMPLE2
 --------
 
     use Terminal::Readsecret;
-    my timespec $timeout .= new(tv_sec => 5, tv_nsec => 0); # set timeout to 5 sec
+    my Timespec $timeout .= new(tv-sec => 5, tv-nsec => 0); # set timeout to 5 sec
     my $password = getsecret("password:", $timeout);
     say "your password is: " ~ $password;
 
@@ -35,9 +35,11 @@ METHODS
 
     proto getsecret(Str:D, |) returns Str
     multi sub getsecret(Str:D) returns Str
-    multi sub getsecret(Str:D, timespec) returns Str
+    multi sub getsecret(Str:D, Timespec) returns Str
 
 Reads secrets or passwords from a command line and returns its input.
+
+NOTE: `timespec` class was removed. Use `Timespec` class instead of `timespec` class.
 
 AUTHOR
 ======

--- a/lib/Terminal/Readsecret.pm6
+++ b/lib/Terminal/Readsecret.pm6
@@ -22,18 +22,31 @@ my Int enum rsecret_error_ty (
 my constant max-secret-length = 1024;
 my constant time_t = int64;
 
-class timespec is repr('CStruct') is export {
-    has time_t $.tv_sec;
-    has int64 $.tv_nsec;
+class Timespec is repr('CStruct') is export {
+    has time_t $!tv_sec;
+    has int64 $!tv_nsec;
+
+    method tv-sec {
+        $!tv_sec
+    }
+
+    method tv-nsec {
+        $!tv_nsec
+    }
+
+    submethod BUILD(Int :$tv-sec, Int :$tv-nsec) {
+        $!tv_sec = $tv-sec;
+        $!tv_nsec = $tv-nsec;
+    }
 }
 
 my sub rsecret_get_secret_from_tty(CArray[uint8], size_t, Str) returns int32 is native($library) is export { * }
-my sub rsecret_get_secret_from_tty_timed(CArray[uint8], size_t, Str, timespec) returns int32 is native($library) is export { * }
+my sub rsecret_get_secret_from_tty_timed(CArray[uint8], size_t, Str, Timespec) returns int32 is native($library) is export { * }
 my sub rsecret_strerror(int32) returns Str is native($library) is export { * }
 
 proto getsecret(Str:D $msg, |) { * }
 
-multi sub getsecret(Str:D $msg, timespec $timeout) returns Str is export {
+multi sub getsecret(Str:D $msg, Timespec $timeout) returns Str is export {
     my $buf = CArray[uint8].new;
     $buf[max-secret-length] = 0;
     my size_t $size = nativesizeof(uint8) * max-secret-length;
@@ -75,7 +88,7 @@ Terminal::Readsecret - A perl6 binding of readsecret ( https://github.com/dmeran
 =head2 EXAMPLE2
 
        use Terminal::Readsecret;
-       my timespec $timeout .= new(tv_sec => 5, tv_nsec => 0); # set timeout to 5 sec
+       my Timespec $timeout .= new(tv-sec => 5, tv-nsec => 0); # set timeout to 5 sec
        my $password = getsecret("password:", $timeout);
        say "your password is: " ~ $password;
 
@@ -90,9 +103,11 @@ Readsecret is a simple self-contained C (or C++) library intended to be used on 
 
        proto getsecret(Str:D, |) returns Str
        multi sub getsecret(Str:D) returns Str
-       multi sub getsecret(Str:D, timespec) returns Str
+       multi sub getsecret(Str:D, Timespec) returns Str
 
 Reads secrets or passwords from a command line and returns its input.
+
+NOTE: C<timespec> class was removed. Use C<Timespec> class instead of C<timespec> class.
 
 =head1 AUTHOR
 

--- a/t/02-password.t
+++ b/t/02-password.t
@@ -3,7 +3,7 @@ use Test;
 use Terminal::Readsecret;
 
 subtest {
-    my $timeout = timespec.new(tv_sec => 1, tv_nsec => 0);
+    my Timespec $timeout .= new(tv-sec => 1, tv-nsec => 0);
     throws-like { getsecret("password", $timeout) }, Exception, message => 'timeout waiting for user';
 }, 'timeout';
 


### PR DESCRIPTION
+ `timespec` class is not Perl6ish, because it is not capitalized.
+ Both `tv_nsec` and `tv_sec` are not Perl6ish, because they don't use kebab case. 