### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,6 +8,7 @@
   "depends" : [ ],
   "description" : "A perl6 binding of readsecret ( https://github.com/dmeranda/readsecret ) for reading secrets or passwords from a command line secretly (not being displayed)",
   "name" : "Terminal::Readsecret",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "Terminal::Readsecret" : "lib/Terminal/Readsecret.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license